### PR TITLE
Fix no logger accessor in UrlDataFileBundle

### DIFF
--- a/lib/queuery_client/url_data_file_bundle.rb
+++ b/lib/queuery_client/url_data_file_bundle.rb
@@ -14,6 +14,7 @@ module QueueryClient
 
     attr_reader :data_files
     attr_reader :s3_prefix
+    attr_reader :logger
 
     def url
       uri = data_files.first.url.dup


### PR DESCRIPTION
UrlDataFileBundle に logger へのアクセッサを追加します。

https://github.com/bricolages/redshift_connector/blob/15b3a9d33fc572ece494a43c9e6d8644adc34ef1/lib/redshift_connector/exporter.rb#L32

ここで使っているため、DataFileBundle には logger アクセッサが必要です。

@aamine レビューお願いします