### PR TITLE
Implement Client#poll_results

### DIFF
--- a/lib/queuery_client/client.rb
+++ b/lib/queuery_client/client.rb
@@ -44,7 +44,8 @@ module QueueryClient
 
     # poll returns the results only if the query has already successed.
     def poll_results(id)
-      get_query_results(id)
+      query = get_query(id)
+      get_query_results(query)
     end
 
     def garage_client
@@ -66,9 +67,7 @@ module QueueryClient
 
     private
 
-    def get_query_results(id)
-      query = get_query(id)
-
+    def get_query_results(query)
       case query.status
       when 'pending', 'running'
         nil

--- a/lib/queuery_client/client.rb
+++ b/lib/queuery_client/client.rb
@@ -7,6 +7,7 @@ module QueueryClient
     def execute_query(select_stmt, values)
       garage_client.post("/v1/queries", q: select_stmt, values: values)
     end
+    alias start_query execute_query
 
     def get_query(id)
       garage_client.get("/v1/queries/#{id}", fields: '__default__,s3_prefix')

--- a/lib/queuery_client/client.rb
+++ b/lib/queuery_client/client.rb
@@ -42,10 +42,10 @@ module QueueryClient
       end
     end
 
-    # poll returns the results only if the query has already successed.
-    def poll_results(id)
+    # poll_result returns the results only if the query has already successed.
+    def poll_result(id)
       query = get_query(id)
-      get_query_results(query)
+      get_query_result(query)
     end
 
     def garage_client
@@ -67,7 +67,7 @@ module QueueryClient
 
     private
 
-    def get_query_results(query)
+    def get_query_result(query)
       case query.status
       when 'pending', 'running'
         nil


### PR DESCRIPTION
This method provides a way to retrieve query results in a non-blocking manner.

I'm not sure how pending, working and failure states shall be handled here; any thoughts?