### PR TITLE
Return Enumerator in DataFile#each and DataFileBundle#each

### DIFF
--- a/lib/queuery_client/data_file.rb
+++ b/lib/queuery_client/data_file.rb
@@ -12,15 +12,21 @@ module QueueryClient
     end
 
     def each_row(&block)
+      return enum_for(:each_row) if !block_given?
+
       f = open
       begin
         if gzipped_object?
           f = Zlib::GzipReader.new(f)
         end
-        RedshiftCsvFile.new(f).each(&block)
+        RedshiftCsvFile.new(f).each do |row|
+          yield row
+        end
       ensure
         f.close
       end
+
+      self
     end
   end
 end

--- a/lib/queuery_client/data_file_bundle.rb
+++ b/lib/queuery_client/data_file_bundle.rb
@@ -3,11 +3,17 @@ module QueueryClient
     # abstract data_files :: [DataFile]
 
     def each_row(&block)
+      return enum_for(:each_row) if !block_given?
+
       data_files.each do |file|
         if file.data_object?
-          file.each_row(&block)
+          file.each_row do |row|
+            yield row
+          end
         end
       end
+
+      self
     end
 
     alias each each_row


### PR DESCRIPTION
QueueryClient#query などで返る DataFileBundle クラスの #each を引数なしで呼んだときに Enumerator が返るようにするパッチです。
Enumerator を返すことで to_a や map が使えるようにすることが目的です。

ただ、この実装では `client.query(sql, []).each.to_a` のように必ず each を経由する必要があり、若干違和感が残ってしまいます。
これを解消するために DataFileBundle で `include Enumerable` することも考えたのですが、行の集合ではなく DataFile の集合である DataFileBundle を行の enumerator として扱って良いのか分からなかったので、この pull request では避けました。

@aamine @KOBA789 レビューお願いします。