### PR TITLE
Support host_header option to use proxy

### DIFF
--- a/lib/queuery_client/client.rb
+++ b/lib/queuery_client/client.rb
@@ -54,7 +54,9 @@ module QueueryClient
         path_prefix: '/',
         login: options.token,
         password: options.token_secret
-      )
+      ).tap do |client|
+        client.headers['Host'] = options.host_header if options.host_header
+      end
     end
 
     def options

--- a/lib/queuery_client/configuration.rb
+++ b/lib/queuery_client/configuration.rb
@@ -1,5 +1,8 @@
 module QueueryClient
   class Configuration
+    REQUIRED_KEYS = [:endpoint, :token, :token_secret]
+    OPTIONAL_KEYS = [:host_header]
+
     def initialize(options = {})
       @options = options
     end
@@ -12,13 +15,19 @@ module QueueryClient
       @options = nil
     end
 
-    [
-      :endpoint,
-      :token,
-      :token_secret,
-    ].each do |key|
+    REQUIRED_KEYS.each do |key|
       define_method(key) do
         options.fetch(key)
+      end
+
+      define_method("#{key}=") do |value|
+        options[key] = value
+      end
+    end
+
+    OPTIONAL_KEYS.each do |key|
+      define_method(key) do
+        options[key]
       end
 
       define_method("#{key}=") do |value|


### PR DESCRIPTION
New configuration `host_header` able to specify `Host` HTTP header.
This option used to connect queuery server over proxy (such as envoy-proxy, haproxy) that routes by `Host` header.