### PR TITLE
Add enable cast option

### DIFF
--- a/lib/queuery_client.rb
+++ b/lib/queuery_client.rb
@@ -17,7 +17,7 @@ module QueueryClient
     end
 
     def query(select_stmt, values = [], enable_cast: false)
-      Client.new.query(select_stmt, values, enable_cast)
+      Client.new.query(select_stmt, values, enable_cast: enable_cast)
     end
   end
 end

--- a/lib/queuery_client.rb
+++ b/lib/queuery_client.rb
@@ -16,8 +16,8 @@ module QueueryClient
       configuration.instance_eval(&block)
     end
 
-    def query(select_stmt, values = [])
-      Client.new.query(select_stmt, values)
+    def query(select_stmt, values = [], enable_cast: false)
+      Client.new.query(select_stmt, values, enable_cast)
     end
   end
 end

--- a/lib/queuery_client/client.rb
+++ b/lib/queuery_client/client.rb
@@ -4,8 +4,8 @@ module QueueryClient
       @options = options
     end
 
-    def execute_query(select_stmt, values, enable_cast)
-      garage_client.post("/v1/queries", q: select_stmt, values: values, enable_cast: enable_cast)
+    def execute_query(select_stmt, values, enable_cast: false)
+      garage_client.post("/v1/queries", q: select_stmt, values: values, enable_metadata: enable_cast)
     end
     alias start_query execute_query
 
@@ -24,13 +24,13 @@ module QueueryClient
       end
     end
 
-    def query_and_wait(select_stmt, values, enable_cast)
-      query = execute_query(select_stmt, values, enable_cast)
+    def query_and_wait(select_stmt, values, enable_cast: false)
+      query = execute_query(select_stmt, values, enable_cast: enable_cast)
       wait_for(query.id)
     end
 
-    def query(select_stmt, values, enable_cast)
-      query = query_and_wait(select_stmt, values, enable_cast)
+    def query(select_stmt, values, enable_cast: false)
+      query = query_and_wait(select_stmt, values, enable_cast: enable_cast)
       case query.status
       when 'success'
         UrlDataFileBundle.new(

--- a/lib/queuery_client/client.rb
+++ b/lib/queuery_client/client.rb
@@ -4,18 +4,19 @@ module QueueryClient
       @options = options
     end
 
-    def execute_query(select_stmt, values, enable_cast: false)
-      garage_client.post("/v1/queries", q: select_stmt, values: values, enable_metadata: enable_cast)
+    def execute_query(select_stmt, values, query_options)
+      garage_client.post("/v1/queries", q: select_stmt, values: values, enable_metadata: query_options[:enable_cast])
     end
     alias start_query execute_query
 
-    def get_query(id)
-      garage_client.get("/v1/queries/#{id}", fields: '__default__,s3_prefix')
+    def get_query(id, query_options)
+      query_option_fields = build_query_option_fields(query_options)
+      garage_client.get("/v1/queries/#{id}", fields: '__default__,s3_prefix' + query_option_fields)
     end
 
-    def wait_for(id)
+    def wait_for(id, query_options)
       loop do
-        query = get_query(id)
+        query = get_query(id, query_options)
         case query.status
         when 'success', 'failed'
           return query
@@ -24,18 +25,19 @@ module QueueryClient
       end
     end
 
-    def query_and_wait(select_stmt, values, enable_cast: false)
-      query = execute_query(select_stmt, values, enable_cast: enable_cast)
-      wait_for(query.id)
+    def query_and_wait(select_stmt, values, query_options)
+      query = execute_query(select_stmt, values, query_options)
+      wait_for(query.id, query_options)
     end
 
-    def query(select_stmt, values, enable_cast: false)
-      query = query_and_wait(select_stmt, values, enable_cast: enable_cast)
+    def query(select_stmt, values, **query_options)
+      query = query_and_wait(select_stmt, values, query_options)
+      manifest_file_url = query.manifest_file_url if query_options[:enable_cast]
       case query.status
       when 'success'
         UrlDataFileBundle.new(
           query.data_file_urls,
-          query.manifest_file_url,
+          manifest_file_url,
           s3_prefix: query.s3_prefix,
         )
       when 'failed'
@@ -77,11 +79,26 @@ module QueueryClient
       when 'success'
         UrlDataFileBundle.new(
           query.data_file_urls,
-          query.manifest_file_url,
+          nil,
           s3_prefix: query.s3_prefix,
         )
       when 'failure'
         raise QueryError.new(query.error)
+      end
+    end
+
+    def build_query_option_fields(query_options)
+      enable_query_options = query_options.select{ |name, v| name if v }.keys
+      return '' if enable_query_options.empty?
+      query_option_fields = enable_query_options.map{ |option_name| convert_field_name(option_name) }
+      ',' + query_option_fields.join(',')
+    end
+
+    def convert_field_name(option_name)
+      case option_name
+        when :enable_cast
+          'manifest_file_url'
+        # add another option here if you need
       end
     end
   end

--- a/lib/queuery_client/data_file.rb
+++ b/lib/queuery_client/data_file.rb
@@ -2,7 +2,7 @@ require 'redshift_csv_file'
 require 'zlib'
 
 module QueueryClient
-  class DataFile
+  class DataFile # abstract class
     def data_object?
       /\.csv(?:\.|\z)/ =~ File.basename(key)
     end

--- a/lib/queuery_client/data_file_bundle.rb
+++ b/lib/queuery_client/data_file_bundle.rb
@@ -35,7 +35,7 @@ module QueueryClient
           value.to_i
         when 'numeric', 'double precision'
           value.to_f
-        when 'character', 'character varing'
+        when 'character', 'character varying'
           value
         when 'timestamp without time zone', 'timestamp with time zone'
           Time.parse(value)
@@ -44,7 +44,7 @@ module QueueryClient
         when 'boolean'
           value == 'true' ? true : false
         else
-          value
+          raise "not support data type: #{type}"
         end
       end
     end

--- a/lib/queuery_client/data_file_bundle.rb
+++ b/lib/queuery_client/data_file_bundle.rb
@@ -5,6 +5,7 @@ module QueueryClient
   class DataFileBundle
     # abstract data_files :: [DataFile]
     # abstract manifest_file :: ManifestFile
+    # abstract def has_manifest?
 
     def each_row(&block)
       return enum_for(:each_row) if !block_given?

--- a/lib/queuery_client/data_file_bundle.rb
+++ b/lib/queuery_client/data_file_bundle.rb
@@ -1,6 +1,10 @@
+require 'date'
+require 'time'
+
 module QueueryClient
   class DataFileBundle
     # abstract data_files :: [DataFile]
+    # abstract manifest_file :: ManifestFile
 
     def each_row(&block)
       return enum_for(:each_row) if !block_given?
@@ -8,14 +12,40 @@ module QueueryClient
       data_files.each do |file|
         if file.data_object?
           file.each_row do |row|
-            yield row
+            if has_manifest?
+              yield type_cast(row)
+            else
+              yield row
+            end
           end
         end
       end
 
       self
     end
-
     alias each each_row
+
+    def type_cast(row)
+      row.zip(manifest_file.column_types).map do |value, type|
+        next nil if (value == '' and type != 'character varing') # null becomes '' on unload
+
+        case type
+        when 'smallint', 'integer', 'bigint'
+          value.to_i
+        when 'numeric', 'double precision'
+          value.to_f
+        when 'character', 'character varing'
+          value
+        when 'timestamp without time zone', 'timestamp with time zone'
+          Time.parse(value)
+        when 'date'
+          Date.parse(value)
+        when 'boolean'
+          value == 'true' ? true : false
+        else
+          value
+        end
+      end
+    end
   end
 end

--- a/lib/queuery_client/data_file_bundle.rb
+++ b/lib/queuery_client/data_file_bundle.rb
@@ -26,6 +26,8 @@ module QueueryClient
     end
     alias each each_row
 
+    private
+
     def type_cast(row)
       row.zip(manifest_file.column_types).map do |value, type|
         next nil if (value == '' and type != 'character varing') # null becomes '' on unload

--- a/lib/queuery_client/manifest_file.rb
+++ b/lib/queuery_client/manifest_file.rb
@@ -7,13 +7,14 @@ module QueueryClient
     end
 
     def column_types
-      f = open
-      begin
-        j = JSON.load(f)
-        j['schema']['elements'].map{|x| x['type']['base']}
-      ensure
-        f.close
-      end
+      @column_types ||=
+        begin
+          f = open
+          j = JSON.load(f)
+          j['schema']['elements'].map{|x| x['type']['base']}
+        ensure
+          f.close
+        end
     end
   end
 end

--- a/lib/queuery_client/manifest_file.rb
+++ b/lib/queuery_client/manifest_file.rb
@@ -1,0 +1,23 @@
+require 'json'
+
+module QueueryClient
+  class ManifestFile
+    def manifest_object?
+      /\.manifest(?:\.|\z)/ =~ File.basename(key)
+    end
+
+    def column_types
+      f = open
+      begin
+        j = JSON.load(f)
+        j['schema']['elements'].map{|x| x['type']['base']}
+      ensure
+        f.close
+      end
+    end
+
+    def has_manifest?
+      !manifest_file.nil?
+    end
+  end
+end

--- a/lib/queuery_client/manifest_file.rb
+++ b/lib/queuery_client/manifest_file.rb
@@ -1,7 +1,7 @@
 require 'json'
 
 module QueueryClient
-  class ManifestFile
+  class ManifestFile # abstract class
     def manifest_object?
       /\.manifest(?:\.|\z)/ =~ File.basename(key)
     end
@@ -14,10 +14,6 @@ module QueueryClient
       ensure
         f.close
       end
-    end
-
-    def has_manifest?
-      !manifest_file.nil?
     end
   end
 end

--- a/lib/queuery_client/redshift_data_type.rb
+++ b/lib/queuery_client/redshift_data_type.rb
@@ -1,0 +1,27 @@
+
+module QueueryClient
+  module RedshiftDataType
+    def self.type_cast(row, manifest_file)
+      row.zip(manifest_file.column_types).map do |value, type|
+        next nil if (value == '' and type != 'character varing') # null becomes '' on unload
+
+        case type
+        when 'smallint', 'integer', 'bigint'
+          value.to_i
+        when 'numeric', 'double precision'
+          value.to_f
+        when 'character', 'character varying'
+          value
+        when 'timestamp without time zone', 'timestamp with time zone'
+          Time.parse(value)
+        when 'date'
+          Date.parse(value)
+        when 'boolean'
+          value == 'true' ? true : false
+        else
+          raise "not support data type: #{type}"
+        end
+      end
+    end
+  end
+end

--- a/lib/queuery_client/s3_data_file_bundle.rb
+++ b/lib/queuery_client/s3_data_file_bundle.rb
@@ -31,5 +31,9 @@ module QueueryClient
       obj = b.object("#{@prefix}manifest")
       S3ManifestFile.new(obj)
     end
+
+    def has_manifest?
+      !manifest_file.nil?
+    end
   end
 end

--- a/lib/queuery_client/s3_data_file_bundle.rb
+++ b/lib/queuery_client/s3_data_file_bundle.rb
@@ -1,5 +1,6 @@
 require 'queuery_client/data_file_bundle'
 require 'queuery_client/s3_data_file'
+require 'queuery_client/s3_manifest_file'
 require 'aws-sdk-s3'
 require 'logger'
 
@@ -23,6 +24,12 @@ module QueueryClient
     def data_files
       b = Aws::S3::Resource.new(client: @s3_client).bucket(@bucket)
       b.objects(prefix: @prefix).map {|obj| S3DataFile.new(obj) }
+    end
+
+    def manifest_file
+      b = Aws::S3::Resource.new(client: @s3_client).bucket(@bucket)
+      obj = b.object("#{@prefix}manifest")
+      S3ManifestFile.new(obj)
     end
   end
 end

--- a/lib/queuery_client/s3_manifest_file.rb
+++ b/lib/queuery_client/s3_manifest_file.rb
@@ -1,0 +1,18 @@
+require 'queuery_client/manifest_file'
+require 'forwardable'
+
+module QueueryClient
+  class S3ManifestFile < ManifestFile
+    extend Forwardable
+
+    def initialize(object)
+      @object = object
+    end
+
+    def_delegators '@object', :url, :key, :presigned_url
+
+    def open
+      @object.get.body
+    end
+  end
+end

--- a/lib/queuery_client/url_data_file_bundle.rb
+++ b/lib/queuery_client/url_data_file_bundle.rb
@@ -1,18 +1,21 @@
 require 'queuery_client/data_file_bundle'
 require 'queuery_client/url_data_file'
+require 'queuery_client/url_manifest_file'
 require 'uri'
 require 'logger'
 
 module QueueryClient
   class UrlDataFileBundle < DataFileBundle
-    def initialize(urls, s3_prefix:, logger: Logger.new($stderr))
-      raise ArgumentError, 'no URL given' if urls.empty?
-      @data_files = urls.map {|url| UrlDataFile.new(URI.parse(url)) }
+    def initialize(data_urls, manifest_url, s3_prefix:, logger: Logger.new($stderr))
+      raise ArgumentError, 'no URL given' if data_urls.empty?
+      @data_files = data_urls.map {|url| UrlDataFile.new(URI.parse(url)) }
+      @manifest_file = UrlManifestFile.new(URI.parse(manifest_url)) if manifest_url
       @s3_prefix = s3_prefix
       @logger = logger
     end
 
     attr_reader :data_files
+    attr_reader :manifest_file
     attr_reader :s3_prefix
     attr_reader :logger
 

--- a/lib/queuery_client/url_data_file_bundle.rb
+++ b/lib/queuery_client/url_data_file_bundle.rb
@@ -32,5 +32,9 @@ module QueueryClient
       prefix = s3_uri.path[1..-1] # trim heading slash
       S3DataFileBundle.new(bucket, prefix)
     end
+
+    def has_manifest?
+      !@manifest_file.nil?
+    end
   end
 end

--- a/lib/queuery_client/url_manifest_file.rb
+++ b/lib/queuery_client/url_manifest_file.rb
@@ -1,0 +1,28 @@
+require 'queuery_client/manifest_file'
+require 'net/http'
+require 'stringio'
+require 'json'
+
+module QueueryClient
+  class UrlManifestFile < ManifestFile
+    def initialize(url)
+      @url = url
+    end
+
+    attr_reader :url
+
+    def key
+      @url.path
+    end
+
+    def open
+      http = Net::HTTP.new(@url.host, @url.port)
+      http.use_ssl = (@url.scheme.downcase == 'https')
+      content = http.start {
+        res = http.get(@url.request_uri)
+        res.body
+      }
+      StringIO.new(content)
+    end
+  end
+end


### PR DESCRIPTION
RedshiftのUnloadで使えるMANIFESTオプションを有効にできるようにします
https://docs.aws.amazon.com/ja_jp/redshift/latest/dg/r_UNLOAD.html

有効にすると出力された `result.csv.manifest` ファイルにある型定義をもとに結果を自動で型変換します。
valuesを省力しても動きます。互換性を考えて無指定の場合は従来通り動きます。

```ruby
bundle = QueueryClient.query('select 0, 1.23, 'hoge', current_date')
bundle.each.to_a
# => [['0', '1.23', '2021-08-30 00:00:00']]

bundle = QueueryClient.query('select 0, 1.23, 'hoge', current_date', enable_cast: true)
bundle.each.to_a
# => [[0, 1.23,  #<Date: 2021-08-30 ((2459457j,0s,0n),+0s,2299161j)>]]
```
