### PR TITLE
Fix type cast for Boolean

### DIFF
--- a/lib/queuery_client/redshift_data_type.rb
+++ b/lib/queuery_client/redshift_data_type.rb
@@ -1,6 +1,17 @@
 
 module QueueryClient
   module RedshiftDataType
+    FALSE_VALUES = [
+      false, 0,
+      "0", :"0",
+      "f", :f,
+      "F", :F,
+      "false", :false,
+      "FALSE", :FALSE,
+      "off", :off,
+      "OFF", :OFF,
+    ].to_set.freeze
+
     def self.type_cast(row, manifest_file)
       row.zip(manifest_file.column_types).map do |value, type|
         next nil if (value == '' and type != 'character varing') # null becomes '' on unload
@@ -17,7 +28,7 @@ module QueueryClient
         when 'date'
           Date.parse(value)
         when 'boolean'
-          value == 'true' ? true : false
+          FALSE_VALUES.include?(value) ? false : true
         else
           raise "not support data type: #{type}"
         end


### PR DESCRIPTION
https://github.com/bricolages/queuery_client/pull/7 の型キャストに不備がありました。
Booleanの真偽が逆になっています。

`ActiveRecord::Type::Boolean#cast` を参考に直しました。