### PR TITLE
Fix S3DataFileBundle for transport_delta/all by QueueryDirectDataSource

### DIFF
--- a/lib/queuery_client/s3_data_file_bundle.rb
+++ b/lib/queuery_client/s3_data_file_bundle.rb
@@ -23,13 +23,19 @@ module QueueryClient
 
     def data_files
       b = Aws::S3::Resource.new(client: @s3_client).bucket(@bucket)
-      b.objects(prefix: @prefix).map {|obj| S3DataFile.new(obj) }
+      b.objects(prefix: @prefix)
+        .select {|obj| obj.key.include?('_part_') }
+        .map {|obj| S3DataFile.new(obj) }
     end
 
     def manifest_file
       b = Aws::S3::Resource.new(client: @s3_client).bucket(@bucket)
       obj = b.object("#{@prefix}manifest")
-      S3ManifestFile.new(obj)
+      if obj.exists?
+        S3ManifestFile.new(obj)
+      else
+        nil
+      end
     end
 
     def has_manifest?


### PR DESCRIPTION
https://github.com/bricolages/queuery_client/pull/7 で追加した型キャスト機能について、`QueueryDirectDataSource` で用いる `S3DataFileBundle` においてミスがありましたので修正です。

#7 ではDirectではない `QueueryDataSource` で用いる `UrlDataFileBundle` を主として開発していましたが、`data_files` や `manifest_file` の仕様がそちらと揃っていませんでした。具体的には下記2つのミスです。
- unloadによりmanifest.jsonが吐かれるときに `S3DataFileBundle#data_files` が `manifest.json` を含んでいた
  - manifest.jsonをCSVファイルと思って処理しようとしてしまってエラーになる
- manifest.jsonがないときに `S3DataFileBundle#manifest_file` が nilを返さなかった
  - `S3DataFileBundle#has_manifest?` が trueを返し、manifest.jsonがないのに型キャストしようとしてエラーになる