### PR TITLE
Modify Redshift data type cast for timestamp

### DIFF
--- a/lib/queuery_client/redshift_data_type.rb
+++ b/lib/queuery_client/redshift_data_type.rb
@@ -24,7 +24,7 @@ module QueueryClient
         when 'character', 'character varying'
           value
         when 'timestamp without time zone', 'timestamp with time zone'
-          Time.parse(value)
+          value # Ruby does not have a class without timezone
         when 'date'
           Date.parse(value)
         when 'boolean'


### PR DESCRIPTION
`manifest.json` を元にした型キャストを実際に試していくと時刻型を使ったカラムのタイムゾーンで問題が起こりました。`Time.parse` でタイムゾーンが自動的につけられ、そこにRailsのARでタイムゾーンが解釈（＝時刻変換）されてSQL化されました。

Redshiftの中ではタイムゾーンがほぼ存在せず、また様々なデータソースを元に集約するDWH基盤であるため統一したタイムゾーンをつけられません。テーブルごとに解釈しなおしても、それを扱う側にもまたタイムゾーンがあるためややこしくなります。

このため本来はタイムゾーンの無い時刻系クラス（JavaでいうLocalTime）に置き換えたいのですが、RubyやRailsでそれに該当するクラスが見つかりませんでした。仕方ないため下手にタイムゾーンがついてしまう`Time.parse`をやめて文字列のまま扱うことにします。こうすることでMySQLのテーブルにはRedshiftのテーブルに書かれた時刻がそのまま入るようになります。