### PR TITLE
fix: Clients should not poll too much, use exponential backoff

### DIFF
--- a/lib/queuery_client/client.rb
+++ b/lib/queuery_client/client.rb
@@ -14,14 +14,18 @@ module QueueryClient
       garage_client.get("/v1/queries/#{id}", fields: '__default__,s3_prefix' + query_option_fields)
     end
 
+    MAX_POLLING_INTERVAL = 30
+
     def wait_for(id, query_options)
+      n = 0
       loop do
         query = get_query(id, query_options)
         case query.status
         when 'success', 'failed'
           return query
         end
-        sleep 3
+        n += 1
+        sleep [3 * n, MAX_POLLING_INTERVAL].min
       end
     end
 


### PR DESCRIPTION
おそらくRedshift Data APIはクエリーの結果をRedshiftに問い合わせているため、3秒ごとにポーリングすると即座に詰まる。最大30秒までクエリー間隔を伸ばしていくようにする。